### PR TITLE
a small improvement in realloc

### DIFF
--- a/source/bestfit.c
+++ b/source/bestfit.c
@@ -80,7 +80,6 @@ void* bfit_reclaim_chunk(bfitRoot_t* root, size_t sz) {
 void* bfit_reclaim_aligned_chunk(bfitRoot_t* root,size_t sz, size_t alignment) {
 	if(!root || !sz || !alignment) return NULL;
 
-
 	dbg_print("====== aligned chunk request @(%zu / %zu) ======= \n", sz, alignment);
 
 	// set minimum required size for bestfit allocator

--- a/source/segment.c
+++ b/source/segment.c
@@ -179,7 +179,7 @@ static DECLARE_TRAVERSE_CALLBACK(segment_for_each_contains) {
 	if((size_t) targ->addr < (size_t) (seg_node->cache_node.top - seg_node->cache_node.base_size))
 		return TRAVERSE_OK;
 	targ->found = TRUE;
-	return TRAVERSE_OK;
+	return TRAVERSE_BREAK;
 }
 
 static DECLARE_ONADDED(segment_internal_onadd) {

--- a/source/test/bfit_test/main.c
+++ b/source/test/bfit_test/main.c
@@ -26,7 +26,7 @@ static void* test_bfit(void* );
 #define LOOP_CNT                           40
 #define TEST_CNT                           40000
 #define MAX_REQ_SIZE                       8192
-#define TH_CNT                             1
+#define TH_CNT                             10
 
 
 
@@ -48,9 +48,6 @@ static void perf_test_oldmalloc(void);
 
 
 int main(void){
-
-	perf_test_nmalloc();
-/*
 
 	pid_t pid = fork();
 	if(pid > 0) {
@@ -76,7 +73,7 @@ int main(void){
 	{
 		perror("fork fail\n");
 		exit(-1);
-	}*/
+	}
 	return 0;
 }
 

--- a/source/test/malloc_test/main.c
+++ b/source/test/malloc_test/main.c
@@ -15,17 +15,9 @@
 
 static void* test_ym(void* );
 
-#ifndef SEGMENT_UNIT_SIZE
-#define SEGMNET_UNIT_SIZE                (1 << 24)
-#endif
-
-#ifndef BFITCACHE_UNIT_SIZE
-#define BFITCACHE_UNIT_SIZE               (1 << 21)
-#endif
-
 #define LOOP_CNT                           40
 #define TEST_CNT                           40000
-#define REALLOC_MAX_SIZE                   (1 << 22)
+#define REALLOC_MAX_SIZE                   (1 << 20)
 #define MAX_REQ_SIZE                       8192
 #define TH_CNT                             20
 
@@ -42,7 +34,6 @@ static void perf_test_oldmalloc(void);
 
 
 int main(void){
-//	perf_test_nmalloc();
 	pid_t pid = fork();
 	if(pid > 0) {
 		wait(NULL);
@@ -412,7 +403,7 @@ static void perf_test_nmalloc(void)
 {
 	int i,j;
 	struct test_report rpt = {0,};
-	for (j = 0; j < 2; j++) {
+	for (j = 0; j < 5; j++) {
 		for (i = 0; i < TH_CNT; i++) {
 			pthread_create(&thrs[i], NULL, test_ym, &reports[i]);
 		}
@@ -440,7 +431,7 @@ static void perf_test_oldmalloc(void)
 {
 	int j,i;
 	struct test_report rpt = {0,};
-	for(j = 0;j < 2; j++) {
+	for(j = 0;j < 5; j++) {
 		for (i = 0; i < TH_CNT; i++) {
 			pthread_create(&thrs[i], NULL, malloc_test, &reports[i]);
 		}


### PR DESCRIPTION
- when finding the segement from which the chunk is originated, exhaustive search is used.
  but actually, the search should be terminated , just after finding the originated one.

Signed-off-by: fritzprix innocentevil0914@gmail.com
